### PR TITLE
feat: Add report starter.

### DIFF
--- a/src/main/java/org/spin/processor/server/ProcessorServer.java
+++ b/src/main/java/org/spin/processor/server/ProcessorServer.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
 
+import org.compiere.jr.report.ReportStarter;
 import org.compiere.util.Env;
 import org.spin.processor.controller.Processors;
 import org.spin.processor.setup.SetupLoader;
@@ -76,6 +77,9 @@ public class ProcessorServer {
 	private void start() throws IOException {
 		//	Start based on provider
 		Env.setContextProvider(contextProvider);
+		ReportStarter.setReportViewerProvider(
+			new ServerReportProvider()
+		);
 
 		logger.info("Service Template added on " + SetupLoader.getInstance().getServer().getPort());
 		//	

--- a/src/main/java/org/spin/processor/server/ServerReportProvider.java
+++ b/src/main/java/org/spin/processor/server/ServerReportProvider.java
@@ -1,0 +1,15 @@
+package org.spin.processor.server;
+
+import org.compiere.jr.report.JRViewerProvider;
+
+import net.sf.jasperreports.engine.JRException;
+import net.sf.jasperreports.engine.JasperPrint;
+
+public class ServerReportProvider implements JRViewerProvider {
+
+	@Override
+	public void openViewer(JasperPrint jasperPrint, String title) throws JRException {
+		//	Nothing here
+	}
+
+}


### PR DESCRIPTION


If a jasper report is executed in the programmer, an error is generated because it does not get a `JRViewerProvider` 

https://github.com/adempiere/adempiere/blob/develop/JasperReports/src/org/compiere/jr/report/ReportStarter.java#L673-L676

Which is already implemented in the swing and zk clients.

https://github.com/adempiere/adempiere/blob/develop/zkwebui/WEB-INF/src/org/adempiere/webui/window/ZkJRViewerProvider.java

https://github.com/adempiere/adempiere/blob/develop/client/src/org/compiere/jr/report/SwingJRViewerProvider.java

Based on:
https://github.com/Systemhaus-Westfalia/adempiere-grpc-server/blob/feature/shw/master/src/main/java/org/spin/server/ServerReportProvider.java 

Also implement on adempiere-grpc-server
https://github.com/Systemhaus-Westfalia/adempiere-grpc-server/blob/feature/shw/master/src/main/java/org/spin/server/AllInOneServices.java#L137-L139





```log
2025-04-08T06:04:29.676179241Z ===========> ProcessUtil.startJavaProcess: org.compiere.jr.report.ReportStarter [20]
2025-04-08T06:04:29.676212430Z java.lang.NullPointerException
2025-04-08T06:04:29.676217371Z 	at org.compiere.jr.report.ReportStarter.startProcess(ReportStarter.java:666)
2025-04-08T06:04:29.676221780Z 	at org.adempiere.util.ProcessUtil.startJavaProcess(ProcessUtil.java:171)
2025-04-08T06:04:29.676225553Z 	at org.adempiere.util.ProcessUtil.startJavaProcess(ProcessUtil.java:116)
2025-04-08T06:04:29.676229382Z 	at org.compiere.process.ServerProcessCtl.startProcess(ServerProcessCtl.java:357)
2025-04-08T06:04:29.676233089Z 	at org.compiere.process.ServerProcessCtl.run(ServerProcessCtl.java:226)
2025-04-08T06:04:29.676236746Z 	at org.eevolution.services.dsl.ProcessBuilder.run(ProcessBuilder.java:223)
2025-04-08T06:04:29.676240439Z 	at org.eevolution.services.dsl.ProcessBuilder.lambda$execute$0(ProcessBuilder.java:270)
2025-04-08T06:04:29.676244234Z 	at org.compiere.util.Trx.run(Trx.java:529)
2025-04-08T06:04:29.676247869Z 	at org.compiere.util.Trx.run(Trx.java:497)
2025-04-08T06:04:29.676251610Z 	at org.eevolution.services.dsl.ProcessBuilder.execute(ProcessBuilder.java:268)
2025-04-08T06:04:29.676255466Z 	at org.shw.lsv.einvoice.process.EI_C_Invoice_Print.getPDF(EI_C_Invoice_Print.java:171)
2025-04-08T06:04:29.676259919Z 	at org.shw.lsv.einvoice.process.EI_C_Invoice_Print.sendIndividualMail(EI_C_Invoice_Print.java:117)
2025-04-08T06:04:29.676263756Z 	at org.shw.lsv.einvoice.process.EI_C_Invoice_Print.sendEMail(EI_C_Invoice_Print.java:178)
2025-04-08T06:04:29.676267370Z 	at org.shw.lsv.einvoice.process.EI_C_Invoice_Print.doIt(EI_C_Invoice_Print.java:77)
2025-04-08T06:04:29.676271021Z 	at org.compiere.process.SvrProcess.process(SvrProcess.java:176)
2025-04-08T06:04:29.676274608Z 	at org.compiere.process.SvrProcess.startProcess(SvrProcess.java:129)
2025-04-08T06:04:29.676278203Z 	at org.adempiere.util.ProcessUtil.startJavaProcess(ProcessUtil.java:171)
2025-04-08T06:04:29.676281932Z 	at org.compiere.process.ServerProcessCtl.startProcess(ServerProcessCtl.java:359)
2025-04-08T06:04:29.676285726Z 	at org.compiere.process.ServerProcessCtl.run(ServerProcessCtl.java:198)
```