### PR TITLE
fix: Upload release assets.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@
 
 name: Continuous Integration with Gradle
 
+permissions:
+  contents: write # to upload release assets
+  packages: write # to publish packages
+
 on:
   push:
     branches:
@@ -47,7 +51,7 @@ jobs:
           java-version: 17
           architecture: x64
 
-      - name: Setup Gradle
+      - name: Setup Gradle 9
         uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: current # 9.0.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@
 
 name: Publish Project
 
+permissions:
+  contents: write # to upload release assets
+  packages: write # to publish packages
+
 on:
   release:
     types:
@@ -28,19 +32,16 @@ jobs:
           java-version: 17
           architecture: x64
 
-      - name: Setup Gradle
+      - name: Setup Gradle 9
         uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: current # 9.0.0
 
-      - name: Set Main Version
-        run: echo "MAIN_VERSION=${{ github.event.release.name }}" >> src/main/java/org/spin/base/version.properties
-
-      - name: Set Release Date
-        run: echo "DATE_VERSION=$(date +'%Y-%m-%d')" >> src/main/java/org/spin/base/version.properties
-
-      - name: Set Implementation Version
-        run: echo "IMPLEMENTATION_VERSION=${{ github.event.release.tag_name }}" >> src/main/java/org/spin/base/version.properties
+      - name: Set Version Properties
+        run: |
+          echo "MAIN_VERSION=${{ github.event.release.name }}" >> src/main/java/org/spin/base/version.properties
+          echo "DATE_VERSION=$(date +'%Y-%m-%d')" >> src/main/java/org/spin/base/version.properties
+          echo "IMPLEMENTATION_VERSION=${{ github.event.release.tag_name }}" >> src/main/java/org/spin/base/version.properties
 
       - name: Create Release with Gradle
         run: gradle createRelease
@@ -52,82 +53,48 @@ jobs:
           GITHUB_DEPLOY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_DEPLOY_REPOSITORY: ${{ secrets.DEPLOY_REPOSITORY }}
 
-      - name: Upload descriptor file artifact
+      - name: Prepare flat artifacts
+        run: |
+          mkdir -p flat_artifacts/
+          cp build/descriptors/adempiere-processors-service.dsc flat_artifacts/ || echo "Warning: .dsc file not found"
+          cp build/release/adempiere-processors-service.* flat_artifacts/ || echo "Warning: release files not found"
+          cp resources/env.yaml flat_artifacts/ || echo "Warning: env.yaml not found"
+          ls -la flat_artifacts/
+
+      - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: adempiere-processors-service.dsc
-          path: build/descriptors/adempiere-processors-service.dsc
+          name: release-artifacts
+          path: flat_artifacts/*
           retention-days: 1
 
-      - name: Upload dist app zip artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: adempiere-processors-service.zip
-          path: build/release/adempiere-processors-service.zip
 
-      - name: Upload dist app zip.MD5 artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: adempiere-processors-service.zip.MD5
-          path: build/release/adempiere-processors-service.zip.MD5
-
-      - name: Upload dist app tar artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: adempiere-processors-service.tar
-          path: build/release/adempiere-processors-service.tar
-
-      - name: Upload dist app tar.MD5 artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: adempiere-processors-service.tar.MD5
-          path: build/release/adempiere-processors-service.tar.MD5
 
   publish-binaries:
-    name: Upload Binaries adempiere-processors-service
+    name: Publish Release Assets
     needs: build-app
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: Download all artifacts
+      - name: Download artifacts
         uses: actions/download-artifact@v4
+        with:
+          name: release-artifacts
+          path: artifacts/
 
-      - name: Upload Descriptor
-        uses: skx/github-action-publish-binaries@master
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          files: |
+            artifacts/adempiere-processors-service.dsc
+            artifacts/adempiere-processors-service.zip
+            artifacts/adempiere-processors-service.zip.MD5
+            artifacts/adempiere-processors-service.tar
+            artifacts/adempiere-processors-service.tar.MD5
+            artifacts/env.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: adempiere-processors-service.dsc/adempiere-processors-service.dsc
 
-      - name: Upload zip
-        uses: skx/github-action-publish-binaries@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: adempiere-processors-service.zip/adempiere-processors-service.zip
-
-      - name: Upload zip.MD5
-        uses: skx/github-action-publish-binaries@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: adempiere-processors-service.zip.MD5/adempiere-processors-service.zip.MD5
-
-      - name: Upload tar
-        uses: skx/github-action-publish-binaries@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: adempiere-processors-service.tar/adempiere-processors-service.tar
-
-      - name: Upload tar.MD5
-        uses: skx/github-action-publish-binaries@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: adempiere-processors-service.tar.MD5/adempiere-processors-service.tar.MD5
 
 
   # Check secrets to push image in docker hub registry
@@ -165,13 +132,17 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
-      - name: Download build dist app
+
+      - name: Download dist artifacts
         uses: actions/download-artifact@v4
         with:
-          name: adempiere-processors-service.zip
+          name: release-artifacts
+          path: artifacts/
+
       - name: Unzip Asset
         run: |
-          unzip adempiere-processors-service.zip -d docker/
+          unzip artifacts/adempiere-processors-service.zip -d docker/
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -201,14 +172,16 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
-      - name: Download build dist app
+      - name: Download dist artifacts
         uses: actions/download-artifact@v4
         with:
-          name: adempiere-processors-service.zip
+          name: release-artifacts
+          path: artifacts/
 
       - name: Unzip Asset
         run: |
-          unzip adempiere-processors-service.zip -d docker/
+          unzip artifacts/adempiere-processors-service.zip -d docker/
+
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3
 


### PR DESCRIPTION
* Change deprecated action https://github.com/skx/github-action-publish-binaries/tree/master/ to https://github.com/softprops/action-gh-release
* Add workflow permissions to write packages and contents.

<img width="1920" height="887" alt="imagen" src="https://github.com/user-attachments/assets/37d9d1c6-ac48-46a9-be5c-f84f8085283f" />

<img width="1567" height="836" alt="imagen" src="https://github.com/user-attachments/assets/565d14a6-a761-4538-bcd2-8d3e0162e17c" />


### Additional context
See https://github.com/EdwinBetanc0urt/adempiere-processors-service/releases/tag/test-0.0.5
See https://github.com/EdwinBetanc0urt/adempiere-processors-service/actions/runs/16955835362
